### PR TITLE
Add option allowing the forcing of wikification

### DIFF
--- a/includes/SyntaxHighlight.php
+++ b/includes/SyntaxHighlight.php
@@ -317,6 +317,7 @@ class SyntaxHighlight {
 
 		$isInline = isset( $args['inline'] );
 		$showLines = isset( $args['line'] );
+		$useWikiMarkup = isset( $args['wikify'] );
 		$lexer = self::getLexer( $lang );
 
 		// Post-Pygment HTML transformations.
@@ -378,7 +379,7 @@ class SyntaxHighlight {
 		} else {
 			$output = self::unwrap( $output );
 
-			if ( $parser ) {
+			if ( $parser && !$useWikiMarkup ) {
 				// Use 'nowiki' strip marker to prevent list processing (also known as doBlockLevels()).
 				// However, leave the wrapping <div/> outside to prevent <p/>-wrapping.
 				$marker = $parser::MARKER_PREFIX . '-syntaxhighlightinner-' .

--- a/tests/parser/parserTests.txt
+++ b/tests/parser/parserTests.txt
@@ -191,3 +191,13 @@ cat
 !! html
 cat=Pages_using_deprecated_enclose_attributes sort=
 !! end
+
+!! test
+nowiki overridden
+!! options
+cat
+!! wikitext
+<syntaxhighlight wikify>'''test'''</syntaxhighlight>
+!! html
+<div class="mw-highlight mw-content-ltr" dir="ltr"><pre><strong>test</strong></pre></div>
+!! end


### PR DESCRIPTION
Doesn't add the `<nowiki/>` tags.

I suggest this because on the English Wikipedia, `{{code}}` actually calls `<syntaxhighlight>`, without any way to force syntax highlighting of the contents. This is confusing because one would expect `<code>` tags. I'd open a template request there once it is possible upstream.

This also would allow one to have links in source code, which may be useful.