### PR TITLE
Set HOME in the pygmentize sandbox environment

### DIFF
--- a/includes/Pygmentize.php
+++ b/includes/Pygmentize.php
@@ -351,12 +351,15 @@ class Pygmentize {
 			->firejailDefaultSeccomp()
 			->routeName( 'syntaxhighlight-pygments' );
 
+		// Set HOME so Python does not do a getpwuid() lookup at startup.
+		$environment = [ 'HOME' => wfTempDir() ];
+
 		if ( wfIsWindows() ) {
 			// Python requires the SystemRoot environment variable to initialize (T300223)
-			$command->environment( [
-				'SystemRoot' => getenv( 'SystemRoot' ),
-			] );
+			$environment['SystemRoot'] = getenv( 'SystemRoot' );
 		}
+
+		$command->environment( $environment );
 
 		return $command;
 	}


### PR DESCRIPTION
Shellbox passes almost no environment through to the subprocess, so HOME is unset when pygmentize runs. Python then falls back to a getpwuid() lookup for the home directory at interpreter startup. On systems whose nsswitch.conf routes passwd through sss or systemd, that lookup walks those NSS sources; under a confining MAC policy such as SELinux the accesses (to /var/lib/sss, /etc/passwd and /run/systemd) are denied, producing audit log noise on every highlight.

Set HOME to the temp directory so the lookup is skipped. This mirrors the existing SystemRoot handling for Windows, which sets an environment variable that Python needs at startup for the same reason.